### PR TITLE
Fix incorrect OpenAI parameter

### DIFF
--- a/test_v4.2.py
+++ b/test_v4.2.py
@@ -220,7 +220,7 @@ If the model fails to understand the request or data is missing, return an empty
                 {
                     "role": "user",
                     "content": ai_prompt.format(url, infos, title, language_label),
-                    "token_max": 6000
+                    "max_tokens": 6000
                 }
             ]
         )


### PR DESCRIPTION
## Summary
- fix invalid `token_max` parameter for OpenAI client

## Testing
- `python -m py_compile test_v4.2.py`


------
https://chatgpt.com/codex/tasks/task_e_684a8fc819348333aa857a3fe37de356